### PR TITLE
fix: Model route, layout overflow issue

### DIFF
--- a/src/ModelsExplorerCards.js
+++ b/src/ModelsExplorerCards.js
@@ -35,6 +35,9 @@ export default function ModelsExplorerCards() {
                 display: "flex",
                 flexDirection: "column",
                 flexGrow: 1,
+                boxShadow: "none",
+                border: "none",
+                borderRadius: 0,
               }}
             >
               <CardMedia
@@ -101,6 +104,9 @@ export default function ModelsExplorerCards() {
                 display: "flex",
                 flexDirection: "column",
                 flexGrow: 1,
+                boxShadow: "none",
+                border: "none",
+                borderRadius: 0,
               }}
             >
               <CardMedia
@@ -164,6 +170,9 @@ export default function ModelsExplorerCards() {
                 display: "flex",
                 flexDirection: "column",
                 flexGrow: 1,
+                boxShadow: "none",
+                border: "none",
+                borderRadius: 0,
               }}
             >
               <CardMedia

--- a/src/ModelsExplorerCards.js
+++ b/src/ModelsExplorerCards.js
@@ -1,52 +1,60 @@
-import * as React from 'react';
-import Box from '@mui/material/Box';
-import Grid from '@mui/material/Unstable_Grid2';
-import Card from '@mui/material/Card';
-import CardActions from '@mui/material/CardActions';
-import CardContent from '@mui/material/CardContent';
-import CardMedia from '@mui/material/CardMedia';
-import Button from '@mui/material/Button';
-import Typography from '@mui/material/Typography';
-import ArrowRightAltIcon from '@mui/icons-material/ArrowRightAlt';
-import { Link } from 'react-router-dom';
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Unstable_Grid2";
+import Card from "@mui/material/Card";
+import CardActions from "@mui/material/CardActions";
+import CardContent from "@mui/material/CardContent";
+import CardMedia from "@mui/material/CardMedia";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import ArrowRightAltIcon from "@mui/icons-material/ArrowRightAlt";
+import { Link } from "react-router-dom";
 
 export default function ModelsExplorerCards() {
   return (
-    <Box sx={{ background: 'white' }}>
+    <Box sx={{ background: "white" }}>
       <Box sx={{ flexGrow: 1, pt: 8, pb: 8, flexShrink: 0 }}>
-        <Grid container spacing={2} sx={{ height: '100%' }}>
+        <Grid
+          container
+          spacing={2}
+          sx={{ height: "100%", margin: 0, width: "100%" }}
+        >
           <Grid
             xs={12}
             sm={12}
             md={4}
             sx={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'stretch',
-            }}>
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "stretch",
+            }}
+          >
             <Card
               sx={{
                 maxWidth: 500,
-                display: 'flex',
-                flexDirection: 'column',
+                display: "flex",
+                flexDirection: "column",
                 flexGrow: 1,
-              }}>
+              }}
+            >
               <CardMedia
-                sx={{ objectFit: 'cover' }}
-                component='img'
-                alt='Explorer Models'
-                height='400'
-                image='/images/adventure_tiger.jpg'
+                sx={{ objectFit: "cover" }}
+                component="img"
+                alt="Explorer Models"
+                height="400"
+                width="100%"
+                image="/images/adventure_tiger.jpg"
               />
               <CardContent sx={{ flexGrow: 1 }}>
                 <Typography
                   gutterBottom
-                  variant='h3'
-                  component='div'
-                  sx={{ textTransform: 'uppercase' }}>
+                  variant="h3"
+                  component="div"
+                  sx={{ textTransform: "uppercase" }}
+                >
                   ADVENTURE
                 </Typography>
-                <Typography variant='body2' color='text.secondary'>
+                <Typography variant="body2" color="text.secondary">
                   State-of-the-art adventure motorcycles with thrilling
                   signature triple engines, innovative progressive technology
                   and equipment, commanding rider ergonomics, and agile neutral
@@ -54,23 +62,24 @@ export default function ModelsExplorerCards() {
                   and control.
                 </Typography>
               </CardContent>
-              <CardActions sx={{ justifyContent: 'flex-end' }}>
+              <CardActions sx={{ justifyContent: "flex-end" }}>
                 <Button
                   component={Link}
-                  to='/models'
-                  size='small'
+                  to="/models"
+                  size="small"
                   endIcon={<ArrowRightAltIcon />}
                   sx={{
-                    color: 'black',
-                    fontWeight: 'bold',
-                    textTransform: 'uppercase',
+                    color: "black",
+                    fontWeight: "bold",
+                    textTransform: "uppercase",
                     padding: 0,
-                    backgroundColor: 'white',
-                    '&:hover': {
-                      backgroundColor: 'transparent',
-                      color: 'black',
+                    backgroundColor: "white",
+                    "&:hover": {
+                      backgroundColor: "transparent",
+                      color: "black",
                     },
-                  }}>
+                  }}
+                >
                   Explorer ADVENTURE
                 </Button>
               </CardActions>
@@ -81,54 +90,59 @@ export default function ModelsExplorerCards() {
             sm={12}
             md={4}
             sx={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'stretch',
-            }}>
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "stretch",
+            }}
+          >
             <Card
               sx={{
                 maxWidth: 500,
-                display: 'flex',
-                flexDirection: 'column',
+                display: "flex",
+                flexDirection: "column",
                 flexGrow: 1,
-              }}>
+              }}
+            >
               <CardMedia
-                sx={{ objectFit: 'cover' }}
-                component='img'
-                alt='Offers and Finance'
-                height='400'
-                image='/images/triumph_speed.jpg'
+                sx={{ objectFit: "cover" }}
+                component="img"
+                alt="Offers and Finance"
+                height="400"
+                width="100%"
+                image="/images/triumph_speed.jpg"
               />
               <CardContent sx={{ flexGrow: 1 }}>
                 <Typography
                   gutterBottom
-                  variant='h3'
-                  component='div'
-                  sx={{ textTransform: 'uppercase' }}>
+                  variant="h3"
+                  component="div"
+                  sx={{ textTransform: "uppercase" }}
+                >
                   Modern Classics
                 </Typography>
-                <Typography variant='body2' color='text.secondary'>
+                <Typography variant="body2" color="text.secondary">
                   With a sound that stirs your soul, a style that’s truly
                   iconic, and a spirit that burns as bright as ever, the feeling
                   of riding a Triumph Modern Classic is as legendary as the
                   bikes themselves.
                 </Typography>
               </CardContent>
-              <CardActions sx={{ justifyContent: 'flex-end' }}>
+              <CardActions sx={{ justifyContent: "flex-end" }}>
                 <Button
-                  size='small'
+                  size="small"
                   endIcon={<ArrowRightAltIcon />}
                   sx={{
-                    color: 'black',
-                    fontWeight: 'bold',
-                    textTransform: 'uppercase',
+                    color: "black",
+                    fontWeight: "bold",
+                    textTransform: "uppercase",
                     padding: 0,
-                    backgroundColor: 'white',
-                    '&:hover': {
-                      backgroundColor: 'transparent',
-                      color: 'black',
+                    backgroundColor: "white",
+                    "&:hover": {
+                      backgroundColor: "transparent",
+                      color: "black",
                     },
-                  }}>
+                  }}
+                >
                   Explorer Modern Classics
                 </Button>
               </CardActions>
@@ -139,53 +153,58 @@ export default function ModelsExplorerCards() {
             sm={12}
             md={4}
             sx={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'stretch',
-            }}>
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "stretch",
+            }}
+          >
             <Card
               sx={{
                 maxWidth: 500,
-                display: 'flex',
-                flexDirection: 'column',
+                display: "flex",
+                flexDirection: "column",
                 flexGrow: 1,
-              }}>
+              }}
+            >
               <CardMedia
-                sx={{ objectFit: 'cover' }}
-                component='img'
-                alt='Triumph Owners'
-                height='400'
-                image='/images/triumph_streettriple.jpg'
+                sx={{ objectFit: "cover" }}
+                component="img"
+                alt="Triumph Owners"
+                height="400"
+                width="100%"
+                image="/images/triumph_streettriple.jpg"
               />
               <CardContent sx={{ flexGrow: 1 }}>
                 <Typography
                   gutterBottom
-                  variant='h3'
-                  component='div'
-                  sx={{ textTransform: 'uppercase' }}>
+                  variant="h3"
+                  component="div"
+                  sx={{ textTransform: "uppercase" }}
+                >
                   ROADSTERS
                 </Typography>
-                <Typography variant='body2' color='text.secondary'>
+                <Typography variant="body2" color="text.secondary">
                   Performance naked bikes at their game-changing best. Triumph's
                   incredible signature Triple engines, are built for power,
                   torque and instant responsiveness.
                 </Typography>
               </CardContent>
-              <CardActions sx={{ justifyContent: 'flex-end' }}>
+              <CardActions sx={{ justifyContent: "flex-end" }}>
                 <Button
-                  size='small'
+                  size="small"
                   endIcon={<ArrowRightAltIcon />}
                   sx={{
-                    color: 'black',
-                    fontWeight: 'bold',
-                    textTransform: 'uppercase',
+                    color: "black",
+                    fontWeight: "bold",
+                    textTransform: "uppercase",
                     padding: 0,
-                    backgroundColor: 'white',
-                    '&:hover': {
-                      backgroundColor: 'transparent',
-                      color: 'black',
+                    backgroundColor: "white",
+                    "&:hover": {
+                      backgroundColor: "transparent",
+                      color: "black",
                     },
-                  }}>
+                  }}
+                >
                   Explorer ROADSTERS
                 </Button>
               </CardActions>

--- a/src/ModelsExplorerCards.js
+++ b/src/ModelsExplorerCards.js
@@ -65,7 +65,7 @@ export default function ModelsExplorerCards() {
                   and control.
                 </Typography>
               </CardContent>
-              <CardActions sx={{ justifyContent: "flex-end" }}>
+              <CardActions sx={{ justifyContent: "flex-start" }}>
                 <Button
                   component={Link}
                   to="/models"
@@ -133,7 +133,7 @@ export default function ModelsExplorerCards() {
                   bikes themselves.
                 </Typography>
               </CardContent>
-              <CardActions sx={{ justifyContent: "flex-end" }}>
+              <CardActions sx={{ justifyContent: "flex-start" }}>
                 <Button
                   size="small"
                   endIcon={<ArrowRightAltIcon />}
@@ -198,7 +198,7 @@ export default function ModelsExplorerCards() {
                   torque and instant responsiveness.
                 </Typography>
               </CardContent>
-              <CardActions sx={{ justifyContent: "flex-end" }}>
+              <CardActions sx={{ justifyContent: "flex-start" }}>
                 <Button
                   size="small"
                   endIcon={<ArrowRightAltIcon />}

--- a/src/ModelsExplorerTwoCards.js
+++ b/src/ModelsExplorerTwoCards.js
@@ -1,49 +1,56 @@
-import React from 'react';
-import Box from '@mui/material/Box';
-import Grid from '@mui/material/Unstable_Grid2';
-import Card from '@mui/material/Card';
-import CardActions from '@mui/material/CardActions';
-import CardContent from '@mui/material/CardContent';
-import CardMedia from '@mui/material/CardMedia';
-import Button from '@mui/material/Button';
-import Typography from '@mui/material/Typography';
-import ArrowRightAltIcon from '@mui/icons-material/ArrowRightAlt';
-import { Link } from 'react-router-dom';
+import React from "react";
+import Box from "@mui/material/Box";
+import Grid from "@mui/material/Unstable_Grid2";
+import Card from "@mui/material/Card";
+import CardActions from "@mui/material/CardActions";
+import CardContent from "@mui/material/CardContent";
+import CardMedia from "@mui/material/CardMedia";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import ArrowRightAltIcon from "@mui/icons-material/ArrowRightAlt";
+import { Link } from "react-router-dom";
 
 export default function ModelsExplorerTwoCards() {
   return (
-    <Box sx={{ background: 'white' }}>
+    <Box sx={{ background: "white" }}>
       <Box
-        sx={{ flexGrow: 1, pt: 8, flexShrink: 0, background: 'white' }}
-        minHeight={600}>
-        <Grid container spacing={2} minHeight={600}>
+        sx={{ flexGrow: 1, pt: 8, flexShrink: 0, background: "white" }}
+        minHeight={600}
+      >
+        <Grid
+          container
+          spacing={2}
+          sx={{ height: "100%", margin: 0, width: "100%" }}
+        >
           <Grid
             xs={12}
             sm={12}
             md={6}
             sx={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}>
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+            }}
+          >
             <Card>
               <CardMedia
-                sx={{ objectFit: 'cover' }}
-                component='img'
-                width={'100%'}
-                alt='Explorer Models'
-                height='400'
-                image='/images/triumph_daytona.webp'
+                sx={{ objectFit: "cover" }}
+                component="img"
+                width={"100%"}
+                alt="Explorer Models"
+                height="400"
+                image="/images/triumph_daytona.webp"
               />
               <CardContent>
                 <Typography
                   gutterBottom
-                  variant='h3'
-                  component='div'
-                  sx={{ textTransform: 'uppercase' }}>
+                  variant="h3"
+                  component="div"
+                  sx={{ textTransform: "uppercase" }}
+                >
                   Sport
                 </Typography>
-                <Typography variant='body2' color='text.secondary'>
+                <Typography variant="body2" color="text.secondary">
                   Discover the detail in the Daytona DNA. Dynamic sports
                   attitude for every road and every ride, with head-turning
                   style, intuitive agility and thrilling performance to put you
@@ -53,20 +60,21 @@ export default function ModelsExplorerTwoCards() {
               <CardActions>
                 <Button
                   component={Link}
-                  to='/models'
-                  size='small'
+                  to="/models"
+                  size="small"
                   endIcon={<ArrowRightAltIcon />}
                   sx={{
-                    color: 'black',
-                    fontWeight: 'bold',
-                    textTransform: 'uppercase',
+                    color: "black",
+                    fontWeight: "bold",
+                    textTransform: "uppercase",
                     padding: 0,
-                    backgroundColor: 'white',
-                    '&:hover': {
-                      backgroundColor: 'transparent',
-                      color: 'black',
+                    backgroundColor: "white",
+                    "&:hover": {
+                      backgroundColor: "transparent",
+                      color: "black",
                     },
-                  }}>
+                  }}
+                >
                   Explorer Sport
                 </Button>
               </CardActions>
@@ -77,27 +85,30 @@ export default function ModelsExplorerTwoCards() {
             sm={12}
             md={6}
             sx={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}>
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+            }}
+          >
             <Card>
               <CardMedia
-                sx={{ objectFit: 'cover' }}
-                component='img'
-                alt='Offers and Finance'
-                height='400'
-                image='/images/triumph_steeladdition.webp'
+                sx={{ objectFit: "cover" }}
+                component="img"
+                alt="Offers and Finance"
+                height="400"
+                width="100%"
+                image="/images/triumph_steeladdition.webp"
               />
               <CardContent>
                 <Typography
                   gutterBottom
-                  variant='h3'
-                  component='div'
-                  sx={{ textTransform: 'uppercase' }}>
+                  variant="h3"
+                  component="div"
+                  sx={{ textTransform: "uppercase" }}
+                >
                   STEALTH EDITIONS
                 </Typography>
-                <Typography variant='body2' color='text.secondary'>
+                <Typography variant="body2" color="text.secondary">
                   Triumph Stealth Editions – a collection of eight new modern
                   classics showcasing dramatic and unique hand-crafted paint
                   finishes, adding a contemporary twist to Triumph’s iconic
@@ -106,19 +117,20 @@ export default function ModelsExplorerTwoCards() {
               </CardContent>
               <CardActions>
                 <Button
-                  size='small'
+                  size="small"
                   endIcon={<ArrowRightAltIcon />}
                   sx={{
-                    color: 'black',
-                    fontWeight: 'bold',
-                    textTransform: 'uppercase',
+                    color: "black",
+                    fontWeight: "bold",
+                    textTransform: "uppercase",
                     padding: 0,
-                    backgroundColor: 'white',
-                    '&:hover': {
-                      backgroundColor: 'transparent',
-                      color: 'black',
+                    backgroundColor: "white",
+                    "&:hover": {
+                      backgroundColor: "transparent",
+                      color: "black",
                     },
-                  }}>
+                  }}
+                >
                   Explorer STEALTH EDITIONS
                 </Button>
               </CardActions>

--- a/src/ModelsExplorerTwoCards.js
+++ b/src/ModelsExplorerTwoCards.js
@@ -32,7 +32,13 @@ export default function ModelsExplorerTwoCards() {
               alignItems: "center",
             }}
           >
-            <Card>
+            <Card
+              sx={{
+                boxShadow: "none",
+                border: "none",
+                borderRadius: 0,
+              }}
+            >
               <CardMedia
                 sx={{ objectFit: "cover" }}
                 component="img"
@@ -90,7 +96,13 @@ export default function ModelsExplorerTwoCards() {
               alignItems: "center",
             }}
           >
-            <Card>
+            <Card
+              sx={{
+                boxShadow: "none",
+                border: "none",
+                borderRadius: 0,
+              }}
+            >
               <CardMedia
                 sx={{ objectFit: "cover" }}
                 component="img"


### PR DESCRIPTION
The issue was caused by the default negative margins applied to the Grid component in Material-UI (Unstable_Grid2) when spacing is used. This caused horizontal overflow on mobile screen, leading to the page moving left and right.

Adding sx={{ height: '100%', margin: 0, width: '100%' }}